### PR TITLE
Use macOS 10.14 for builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 # borrowed from https://github.com/goreleaser/homebrew-tap
 language: objective-c
+os: osx
+osx_image: xcode11
 before_install:
   - brew update >/dev/null
 script:


### PR DESCRIPTION
Unclear what's causing https://travis-ci.com/github/Kong/homebrew-deck/builds/202495626#L755

However, there is this complaint elsewhere:
> Warning: You are using macOS 10.13.
> We (and Apple) do not provide support for this old version.

Absent the apparent lack of version configuration for Homebrew itself, guessing that it's tied to the CI environment. https://github.com/Kong/homebrew-kong/pull/114/commits/77f5288ff0f9d36ab82af33dfb44f66d2a748676 suggests this will force that to update, which will hopefully make Homebrew less sad.