### PR TITLE
drop bottle :unneeded for it's obsolete

### DIFF
--- a/Formula/deck.rb
+++ b/Formula/deck.rb
@@ -6,7 +6,6 @@ class Deck < Formula
   desc "Declarative configuration for Kong"
   homepage "https://github.com/kong/deck"
   version "1.8.2"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
Seems like this can safely be dropped: https://github.com/Homebrew/brew/pull/11239
Otherwise brew will warn you every time:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the kong/deck tap (not Homebrew/brew or Homebrew/core):
  /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/kong/homebrew-deck/Formula/deck.rb:9
```